### PR TITLE
Normalize IRQ behavior

### DIFF
--- a/hw/riscv/riscv_board.c
+++ b/hw/riscv/riscv_board.c
@@ -164,10 +164,11 @@ static void riscv_board_init(QEMUMachineInitArgs *args)
     // write memory amount in MiB to 0x0
     stl_p(memory_region_get_ram_ptr(main_mem), loaderparams.ram_size >> 20);
 
-#ifdef CONFIG_RISCV_HTIF
+    // add serial device 0x3f8-0x3ff
     serial_mm_init(system_memory, 0x3f8, 0, env->irq[4], 1843200/16, serial_hds[0],
         DEVICE_NATIVE_ENDIAN);
 
+#ifdef CONFIG_RISCV_HTIF
     // setup HTIF Block Device if one is specified as -hda FILENAME
     htifbd_drive = drive_get_by_index(IF_IDE, 0);
     if (NULL == htifbd_drive) {
@@ -179,18 +180,14 @@ static void riscv_board_init(QEMUMachineInitArgs *args)
     // add htif device 0x400 - 0x410
     htif_mm_init(system_memory, 0x400, env->irq[0], main_mem, htifbd_fname);
 #else
-    // add serial device 0x3f8-0x3ff
-    serial_mm_init(system_memory, 0x3f8, 0, env->irq[1], 1843200/16, serial_hds[0],
-        DEVICE_NATIVE_ENDIAN);
-
     /* Create MMIO transports, to which virtio backends created by the
      * user are automatically connected as needed.  If no backend is
      * present, the transport simply remains harmlessly idle.
      * Each memory-mapped region is 0x200 bytes in size.
      */
-    sysbus_create_simple("virtio-mmio", 0x400, env->irq[2]);
-    sysbus_create_simple("virtio-mmio", 0x600, env->irq[3]);
-    sysbus_create_simple("virtio-mmio", 0x800, env->irq[4]);
+    sysbus_create_simple("virtio-mmio", 0x400, env->irq[1]);
+    sysbus_create_simple("virtio-mmio", 0x600, env->irq[2]);
+    sysbus_create_simple("virtio-mmio", 0x800, env->irq[3]);
 #endif
 
     /* Init internal devices */

--- a/target-riscv/op_helper.c
+++ b/target-riscv/op_helper.c
@@ -486,6 +486,9 @@ inline void csr_write_helper(CPURISCVState *env, target_ulong val_to_write, targ
 {
 
     switch (csrno) {
+        case CSR_STATUS:
+            env->helper_csr[CSR_STATUS] = (val_to_write & ~(SR_IP)) | (env->helper_csr[CSR_STATUS] & SR_IP);
+            break;
         case CSR_COUNT:
             cpu_riscv_store_count(env, (uint32_t)val_to_write);
             break;


### PR DESCRIPTION
These patches enable compatibility with the riscv-linux master branch.
QEMU guest support should now only require a different set of built-in drivers.